### PR TITLE
respect prefers-color-scheme for email body (light/dark)

### DIFF
--- a/src/frontend/static/scripts/main.js
+++ b/src/frontend/static/scripts/main.js
@@ -110,6 +110,28 @@ document.addEventListener("DOMContentLoaded", () => {
         refreshBtn.classList.remove('loading');
     }
 
+    // wrap email body so it displays readable and links open in new tab; respects prefers-color-scheme
+    function wrapEmailBodyForReadability(html) {
+        const style = `
+            html, body, body * {
+                background-color: #fff !important;
+                color: #1a1a1a !important;
+            }
+            a { color: #64317f !important; }
+            body { font-family: inherit; padding: 0.5rem 0.75rem; margin: 0; }
+            @media (prefers-color-scheme: dark) {
+                html, body, body * {
+                    background-color: #0e0d0f !important;
+                    color: #f7ebff !important;
+                }
+                a { color: #b87fd4 !important; }
+            }
+        `;
+        let bodyHtml = html.replace(/\btarget\s*=\s*["']?(?:_self|_parent|_top)["']?/gi, 'target="_blank"');
+        bodyHtml = bodyHtml.replace(/<a\s+(?![^>]*\btarget\s*=)/gi, '<a target="_blank" rel="noopener noreferrer" ');
+        return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="color-scheme" content="light dark"><style>${style}</style></head><body>${bodyHtml}</body></html>`;
+    }
+
     // render the inbox in the inbox element
     function renderInbox(inbox) {
         inboxList.innerHTML = '';
@@ -127,7 +149,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         <div class="time">${formatTime(email.Timestamp)}</div>
                     </div>
                     <div class="email-body">
-                        <iframe class="email-body-iframe" srcdoc=""></iframe>
+                        <iframe class="email-body-iframe" sandbox="sandbox allow-popups" srcdoc=""></iframe>
                     </div>
                 `;
                 inboxList.appendChild(emailItem);
@@ -137,7 +159,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     emailItem.classList.toggle('open');
                     const iframe = emailItem.querySelector('.email-body-iframe');
                     if (emailItem.classList.contains('open')) {
-                        iframe.srcdoc = email.Body;
+                        iframe.srcdoc = wrapEmailBodyForReadability(email.Body);
                     }
                 });
             });

--- a/src/frontend/static/styles/style.css
+++ b/src/frontend/static/styles/style.css
@@ -15,6 +15,13 @@
     --container-radius: 8px; /* border radius */
     --content-radius: 5px; /* border radius */
     --font-family: 'Roboto Mono', monospace; /* cool font */
+    --email-body-bg: #ffffff; /* email iframe fallback – light theme */
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --email-body-bg: var(--surface-color);
+    }
 }
 
 * {
@@ -290,12 +297,13 @@ body {
     padding: 0 1rem;
 }
  
-/* email body iframe */
+/* email body iframe – background follows system light/dark */
 .email-body-iframe {
     width: 100%;
     height: 400px;
     border: none;
     border-radius: var(--content-radius);
+    background-color: var(--email-body-bg);
 }
 
 /* the body container (open) */


### PR DESCRIPTION
Makes the email body follow the system theme (prefers-color-scheme):
- Light: White background, dark text.
- Dark: Dark background, light text (aligned with app colours).
Also: readable styling for HTML emails (forced colours), links open in a new tab, and iframe sandbox for safety.
